### PR TITLE
[storage][apps/code] Change sizes

### DIFF
--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -75,7 +75,7 @@ public:
 
   VariableBoxController * variableBoxController() { return &m_variableBoxController; }
 
-  static constexpr int k_pythonHeapSize = 100000;
+  static constexpr int k_pythonHeapSize = 64000;
 
 private:
   /* Python delegate:

--- a/apps/code/app.h
+++ b/apps/code/app.h
@@ -75,7 +75,7 @@ public:
 
   VariableBoxController * variableBoxController() { return &m_variableBoxController; }
 
-  static constexpr int k_pythonHeapSize = 64000;
+  static constexpr int k_pythonHeapSize = 67000;
 
 private:
   /* Python delegate:

--- a/apps/code/variable_box_controller.h
+++ b/apps/code/variable_box_controller.h
@@ -43,7 +43,7 @@ public:
 
 private:
   constexpr static size_t k_maxNumberOfDisplayedItems = (Ion::Display::Height - Metric::TitleBarHeight - Metric::PopUpTopMargin) / ScriptNodeCell::k_simpleItemHeight + 2; // +2 if the cells are cropped on top and at the bottom
-  constexpr static size_t k_maxScriptNodesCount = 128; // Chosen without particular reasons (Number of functions in the variables box)
+  constexpr static size_t k_maxScriptNodesCount = 64; // Chosen without particular reasons (Number of functions in the variables box)
   constexpr static int k_totalBuiltinNodesCount = 107;
   constexpr static uint8_t k_scriptOriginsCount = 8; // Number of scripts loaded in the variable box
   constexpr static uint8_t k_subtitleCellType = NodeCellType; // We don't care as it is not selectable

--- a/ion/include/ion/storage.h
+++ b/ion/include/ion/storage.h
@@ -17,7 +17,7 @@ class Storage {
 public:
   typedef uint16_t record_size_t;
 
-  constexpr static size_t k_storageSize = 32768;
+  constexpr static size_t k_storageSize = 64000;
   static_assert(UINT16_MAX >= k_storageSize, "record_size_t not big enough");
 
   static Storage * sharedStorage();


### PR DESCRIPTION
- `k_pythonHeapSize` -> from 100K to 67K<sup>1,3</sup>
- `k_maxScriptNodesCount` -> from 128 to 64<sup>2</sup>
- `k_storageSize` -> from 32768 to 64K<sup>1</sup>

1: See https://github.com/Omega-Numworks/Omega/issues/540
2: If not : 
  ```cpp
  cannot move location counter backwards (from 00000000200xxxxx to 0000000020038000)
  ```
3: `k_pythonHeapSize` + `k_storageSize` was 132Kb before, but 64+64 is 128 (we lose 4Kb, not cool) so 67Kb for the heap (68 will throw an error)