### PR TITLE
[mpy/kandinsky] Fix draw_string() on new line + good colors

### DIFF
--- a/kandinsky/src/context_text.cpp
+++ b/kandinsky/src/context_text.cpp
@@ -29,7 +29,7 @@ KDPoint KDContext::pushOrPullString(const char * text, KDPoint p, const KDFont *
     codePointPointer = decoder.stringPosition();
     if (codePoint == UCodePointLineFeed) {
       assert(position.y() < KDCOORDINATE_MAX - glyphSize.height());
-      position = KDPoint(0, position.y() + glyphSize.height());
+      position = KDPoint(p.x(), position.y() + glyphSize.height());
       codePoint = decoder.nextCodePoint();
     } else if (codePoint == UCodePointTabulation) {
       position = position.translatedBy(KDPoint(k_tabCharacterWidth * glyphSize.width(), 0));

--- a/python/port/mod/kandinsky/modkandinsky.cpp
+++ b/python/port/mod/kandinsky/modkandinsky.cpp
@@ -57,12 +57,11 @@ mp_obj_t modkandinsky_set_pixel(mp_obj_t x, mp_obj_t y, mp_obj_t input) {
   return mp_const_none;
 }
 
-//TODO Use good colors
 mp_obj_t modkandinsky_draw_string(size_t n_args, const mp_obj_t * args) {
   const char * text = mp_obj_str_get_str(args[0]);
   KDPoint point(mp_obj_get_int(args[1]), mp_obj_get_int(args[2]));
-  KDColor textColor = (n_args >= 4) ? MicroPython::Color::Parse(args[3]) : KDColorBlack;
-  KDColor backgroundColor = (n_args >= 5) ? MicroPython::Color::Parse(args[4]) : KDColorWhite;
+  KDColor textColor = (n_args >= 4) ? MicroPython::Color::Parse(args[3]) : Palette::PrimaryText;
+  KDColor backgroundColor = (n_args >= 5) ? MicroPython::Color::Parse(args[4]) : Palette::HomeBackground;
   const KDFont * font = (n_args >= 6) ? ((mp_obj_is_true(args[5])) ? KDFont::SmallFont : KDFont::LargeFont) : KDFont::LargeFont;
   MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
   KDIonContext::sharedContext()->drawString(text, point, font, textColor, backgroundColor);


### PR DESCRIPTION
Uses `Palette` instead of b/w constants, also doesn't returns to 0 (x coordinate)
<details>
<summary>Screenshots</summary>

With `draw_string("hey\nho\nmatelos", 11, 32)`:
### Before:
<img width="382" alt="Capture d’écran 2021-10-11 à 18 45 40" src="https://user-images.githubusercontent.com/63865385/136835379-b2286731-3b07-4330-824a-6b617c5c3a71.png">

### Now: (correct colors!)
<img width="381" alt="Capture d’écran 2021-10-11 à 20 06 44" src="https://user-images.githubusercontent.com/63865385/136835427-fc85f155-ba56-4224-b40a-47ec179a1895.png">
</details>