### PR TITLE
Replace hard-coded color values with Palette colors and use the correct colors

### DIFF
--- a/apps/calculation/history_view_cell.cpp
+++ b/apps/calculation/history_view_cell.cpp
@@ -81,7 +81,7 @@ void HistoryViewCell::reloadSubviewHighlight() {
   m_ellipsis.setHighlighted(false);
   if (isHighlighted()) {
     if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Input) {
-      m_inputView.setExpressionBackgroundColor(Palette::ListCellBackgroundSelected);
+      m_inputView.setExpressionBackgroundColor(Palette::Select);
     } else if (m_dataSource->selectedSubviewType() == HistoryViewCellDataSource::SubviewType::Output) {
       m_scrollableOutputView.evenOddCell()->setHighlighted(true);
     } else {

--- a/apps/code/script_node_cell.cpp
+++ b/apps/code/script_node_cell.cpp
@@ -21,10 +21,10 @@ void ScriptNodeCell::ScriptNodeView::drawRect(KDContext * ctx, KDRect rect) cons
   const int nodeNameLength = m_scriptNode->nameLength();
   KDSize nameSize = k_font->stringSize(nodeName, nodeNameLength);
   const KDCoordinate nodeNameY = k_topMargin;
-  ctx->drawString(nodeName, KDPoint(0, nodeNameY), k_font, KDColorBlack, backgroundColor, nodeNameLength);
+  ctx->drawString(nodeName, KDPoint(0, nodeNameY), k_font, Palette::PrimaryText, backgroundColor, nodeNameLength);
   // If it is needed, draw the parentheses
   if (m_scriptNode->type() == ScriptNode::Type::WithParentheses) {
-    ctx->drawString(ScriptNodeCell::k_parentheses, KDPoint(nameSize.width(), nodeNameY), k_font, KDColorBlack, backgroundColor);
+    ctx->drawString(ScriptNodeCell::k_parentheses, KDPoint(nameSize.width(), nodeNameY), k_font, Palette::PrimaryText, backgroundColor);
   }
 
   /* If it exists, draw the source name. If it did not fit, we would have put

--- a/apps/math_variable_box_empty_controller.cpp
+++ b/apps/math_variable_box_empty_controller.cpp
@@ -5,7 +5,7 @@
 
 MathVariableBoxEmptyController::MathVariableBoxEmptyView::MathVariableBoxEmptyView() :
   ModalViewEmptyView(),
-  m_layoutExample(0.5f, 0.5f, KDColorBlack, Palette::WallScreen)
+  m_layoutExample(0.5f, 0.5f, Palette::PrimaryText, Palette::WallScreen)
 {
   initMessageViews();
 }

--- a/apps/shared/scrollable_multiple_expressions_view.cpp
+++ b/apps/shared/scrollable_multiple_expressions_view.cpp
@@ -24,13 +24,13 @@ void AbstractScrollableMultipleExpressionsView::ContentCell::setHighlighted(bool
   // Do not call HighlightCell::setHighlighted to avoid marking all cell as dirty
   m_highlighted = highlight;
   KDColor defaultColor = backgroundColor();
-  KDColor color = highlight && m_selectedSubviewPosition == SubviewPosition::Center ? Palette::ExpressionInputBackground : defaultColor;
+  KDColor color = highlight && m_selectedSubviewPosition == SubviewPosition::Center ? Palette::Select : defaultColor;
   m_centeredExpressionView.setBackgroundColor(color);
-  color = highlight && m_selectedSubviewPosition == SubviewPosition::Right ? Palette::ExpressionInputBackground : defaultColor;
+  color = highlight && m_selectedSubviewPosition == SubviewPosition::Right ? Palette::Select : defaultColor;
   m_rightExpressionView.setBackgroundColor(color);
   m_approximateSign.setBackgroundColor(defaultColor);
   if (leftExpressionView()) {
-    color = highlight && m_selectedSubviewPosition == SubviewPosition::Left ? Palette::ExpressionInputBackground : defaultColor;
+    color = highlight && m_selectedSubviewPosition == SubviewPosition::Left ? Palette::Select : defaultColor;
     leftExpressionView()->setBackgroundColor(color);
   }
 }


### PR DESCRIPTION
Some colors are hard coded, such as in the empty variable box (math) or the functions box in the python console.
Some colors were not the right colors, such as the background of the selected expression in the calculation history which also was inconsistent (For the expressions on the left it used `ListCellBackgroundSelected` and for the expressions on the right it used `ExpressionInputBackground` whereas it should use `Select` on both, what is the case in Numworks/Epsilon)
This unfortunately changes the look of certain themes but it makes more sense and leads to less confusion when making new themes.