### PR TITLE
Make battery background use appropriate colors

### DIFF
--- a/apps/battery_view.cpp
+++ b/apps/battery_view.cpp
@@ -75,13 +75,13 @@ void BatteryView::drawRect(KDContext * ctx, KDRect rect) const {
     assert(!m_isPlugged);
     // Low: Quite empty battery
     ctx->fillRect(KDRect(batteryInsideX, 0, 2*k_elementWidth, k_batteryHeight), Palette::BatteryLow);
-    ctx->fillRect(KDRect(3*k_elementWidth+k_separatorThickness, 0, k_batteryWidth-5*k_elementWidth-2*k_separatorThickness, k_batteryHeight), Palette::BatteryInCharge);
+    ctx->fillRect(KDRect(3*k_elementWidth+k_separatorThickness, 0, k_batteryWidth-5*k_elementWidth-2*k_separatorThickness, k_batteryHeight), KDColor::blend(Palette::Toolbar, Palette::Battery, 128));
   } else if (m_chargeState == Ion::Battery::Charge::SOMEWHERE_INBETWEEN) {
     assert(!m_isPlugged);
     // Middle: Half full battery
     constexpr KDCoordinate middleChargeWidth = batteryInsideWidth/2;
     ctx->fillRect(KDRect(batteryInsideX, 0, middleChargeWidth, k_batteryHeight), Palette::Battery);
-    ctx->fillRect(KDRect(batteryInsideX+middleChargeWidth, 0, middleChargeWidth, k_batteryHeight), Palette::BatteryInCharge);
+    ctx->fillRect(KDRect(batteryInsideX+middleChargeWidth, 0, middleChargeWidth, k_batteryHeight), KDColor::blend(Palette::Toolbar, Palette::Battery, 128));
   } else {
     assert(m_chargeState == Ion::Battery::Charge::FULL);
     // Full but not plugged: Full battery


### PR DESCRIPTION
The color to use as background is generated by blending the Palette::Toolbar and Palette::Battery colors with (KDColor::Blend)
Before:
![image](https://user-images.githubusercontent.com/49951010/138729989-db14b3d5-20b8-420c-9b5a-05934626cc5d.png)
![image](https://user-images.githubusercontent.com/49951010/138730082-b448a5b9-7f45-4c31-a267-b0fea1623e3c.png)

After:
![image](https://user-images.githubusercontent.com/49951010/138730133-cc1186d1-f3c0-444c-84a5-600ceae9ae99.png)
![image](https://user-images.githubusercontent.com/49951010/138730143-8e008050-0a15-4666-be64-22e1ff43340c.png)
