### PR TITLE
[apps/settings] Fix gamma selector

### DIFF
--- a/apps/settings/sub_menu/accessibility_controller.cpp
+++ b/apps/settings/sub_menu/accessibility_controller.cpp
@@ -25,7 +25,7 @@ bool AccessibilityController::handleEvent(Ion::Events::Event event) {
   int redGamma, greenGamma, blueGamma;
   KDIonContext::sharedContext()->gamma.gamma(redGamma, greenGamma, blueGamma);
 
-  if (event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) {
+  if ((event == Ion::Events::OK || event == Ion::Events::EXE || event == Ion::Events::Right) && (selectedRow() <= 2)) {
     if (selectedRow() == 0) {
       invertEnabled = !invertEnabled;
     }


### PR DESCRIPTION
In #35, when I added support of right key in settings, I have broken the colour selector of gamma correction. So this pull request fix this bug.