### PR TITLE
Make use theme colors instead of hard-coded ones

### DIFF
--- a/apps/code/toolbox_ion_keys.cpp
+++ b/apps/code/toolbox_ion_keys.cpp
@@ -37,10 +37,10 @@ namespace Code {
     }
 
   void toolboxIonKeys::toolboxIonView::drawRect(KDContext * ctx, KDRect rect) const {
-    ctx->fillRect(rect, Palette::GrayBright);
-    ctx->strokeRect(rect, Palette::GrayDark);
-    ctx->drawString(I18n::translate(I18n::Message::PressAKey),KDPoint(rect.left()+80, rect.top()+20));
-
+    ctx->fillRect(rect, Palette::WallScreen);
+    ctx->strokeRect(rect, Palette::ListCellBorder);
+    ctx->drawString(I18n::translate(I18n::Message::PressAKey),KDPoint(rect.left()+80, rect.top()+20),KDFont::LargeFont,Palette::PrimaryText,Palette::WallScreen);
+  
   }
 
   View * toolboxIonKeys::view(){

--- a/escher/src/modal_view_empty_controller.cpp
+++ b/escher/src/modal_view_empty_controller.cpp
@@ -30,7 +30,7 @@ void ModalViewEmptyController::ModalViewEmptyView::setMessages(I18n::Message * m
 
 void ModalViewEmptyController::ModalViewEmptyView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(bounds(), k_backgroundColor);
-  drawBorderOfRect(ctx, bounds(), Palette::GrayBright);
+  drawBorderOfRect(ctx, bounds(), Palette::ListCellBorder);
 }
 
 int ModalViewEmptyController::ModalViewEmptyView::numberOfSubviews() const {


### PR DESCRIPTION
The empty variable boxes and key selector have more consistent colors, especially visible in dark themes