### PR TITLE
[apps/settings|code] Add a Flag to remove Code option in settings

### DIFF
--- a/apps/code/Makefile
+++ b/apps/code/Makefile
@@ -1,6 +1,8 @@
 apps += Code::App
 app_headers += apps/code/app.h
 
+SFLAGS += -DHAS_CODE
+
 app_code_src = $(addprefix apps/code/,\
   app.cpp \
   console_controller.cpp \

--- a/apps/settings/main_controller.cpp
+++ b/apps/settings/main_controller.cpp
@@ -21,7 +21,9 @@ constexpr SettingsMessageTree s_accessibilityChildren[6] = {SettingsMessageTree(
 constexpr SettingsMessageTree s_contributorsChildren[23] = {SettingsMessageTree(I18n::Message::Developers), SettingsMessageTree(I18n::Message::QuentinGuidee), SettingsMessageTree(I18n::Message::JoachimLeFournis), SettingsMessageTree(I18n::Message::MaximeFriess), SettingsMessageTree(I18n::Message::JeanBaptisteBoric), SettingsMessageTree(I18n::Message::SandraSimmons), SettingsMessageTree(I18n::Message::David), SettingsMessageTree(I18n::Message::DamienNicolet), SettingsMessageTree(I18n::Message::EvannDreumont), SettingsMessageTree(I18n::Message::SzaboLevente), SettingsMessageTree(I18n::Message::VenceslasDuet), SettingsMessageTree(I18n::Message::CharlotteThomas), SettingsMessageTree(I18n::Message::AntoninLoubiere), SettingsMessageTree(I18n::Message::CyprienMejat), SettingsMessageTree(I18n::Message::BetaTesters), SettingsMessageTree(I18n::Message::TimeoArnouts), SettingsMessageTree(I18n::Message::JulieC), SettingsMessageTree(I18n::Message::LelahelHideux), SettingsMessageTree(I18n::Message::Madil), SettingsMessageTree(I18n::Message::HilaireLeRoux), SettingsMessageTree(I18n::Message::HectorNussbaumer), SettingsMessageTree(I18n::Message::RaphaelDyda), SettingsMessageTree(I18n::Message::ThibautC)};
 
 // Code Settings
+#ifdef HAS_CODE
 constexpr SettingsMessageTree s_codeChildren[2] = {SettingsMessageTree(I18n::Message::FontSizes, s_modelFontChildren), SettingsMessageTree(I18n::Message::Autocomplete)};
+#endif
 constexpr SettingsMessageTree s_modelFontChildren[2] = {SettingsMessageTree(I18n::Message::LargeFont), SettingsMessageTree(I18n::Message::SmallFont)};
 
 

--- a/apps/settings/main_controller_prompt_beta.cpp
+++ b/apps/settings/main_controller_prompt_beta.cpp
@@ -13,7 +13,9 @@ constexpr SettingsMessageTree s_modelMenu[] =
     SettingsMessageTree(I18n::Message::Language),
     SettingsMessageTree(I18n::Message::Country),
     SettingsMessageTree(I18n::Message::ExamMode, ExamModeConfiguration::s_modelExamChildren),
+#ifdef HAS_CODE
     SettingsMessageTree(I18n::Message::CodeApp, s_codeChildren),
+#endif
     SettingsMessageTree(I18n::Message::BetaPopUp),
     SettingsMessageTree(I18n::Message::About, s_modelAboutChildren),
     SettingsMessageTree(I18n::Message::Accessibility, s_accessibilityChildren)};

--- a/apps/settings/main_controller_prompt_none.cpp
+++ b/apps/settings/main_controller_prompt_none.cpp
@@ -13,8 +13,9 @@ constexpr SettingsMessageTree s_modelMenu[] =
     SettingsMessageTree(I18n::Message::Language),
     SettingsMessageTree(I18n::Message::Country),
     SettingsMessageTree(I18n::Message::ExamMode, ExamModeConfiguration::s_modelExamChildren),
+#ifdef HAS_CODE
     SettingsMessageTree(I18n::Message::CodeApp, s_codeChildren),
-    SettingsMessageTree(I18n::Message::Accessibility, s_accessibilityChildren),
+#endif    SettingsMessageTree(I18n::Message::Accessibility, s_accessibilityChildren),
     SettingsMessageTree(I18n::Message::About, s_modelAboutChildren)};
 
 constexpr SettingsMessageTree s_model = SettingsMessageTree(I18n::Message::SettingsApp, s_modelMenu);

--- a/apps/settings/main_controller_prompt_update.cpp
+++ b/apps/settings/main_controller_prompt_update.cpp
@@ -13,8 +13,9 @@ constexpr SettingsMessageTree s_modelMenu[] =
     SettingsMessageTree(I18n::Message::Language),
     SettingsMessageTree(I18n::Message::Country),
     SettingsMessageTree(I18n::Message::ExamMode, ExamModeConfiguration::s_modelExamChildren),
+#ifdef HAS_CODE
     SettingsMessageTree(I18n::Message::CodeApp, s_codeChildren),
-    SettingsMessageTree(I18n::Message::UpdatePopUp),
+#endif    SettingsMessageTree(I18n::Message::UpdatePopUp),
     SettingsMessageTree(I18n::Message::Accessibility, s_accessibilityChildren),
     SettingsMessageTree(I18n::Message::About, s_modelAboutChildren)};
 

--- a/apps/settings/sub_menu/code_options_controller.cpp
+++ b/apps/settings/sub_menu/code_options_controller.cpp
@@ -61,11 +61,14 @@ void CodeOptionsController::willDisplayCellForIndex(HighlightCell * cell, int in
     GlobalPreferences::sharedGlobalPreferences()->font() == KDFont::LargeFont
         ? myTextCell->setSubtitle(I18n::Message::LargeFont) 
         : myTextCell->setSubtitle(I18n::Message::SmallFont);
-  } else if (thisLabel == I18n::Message::Autocomplete) {
+  } 
+#ifdef HAS_CODE
+  else if (thisLabel == I18n::Message::Autocomplete) {
     MessageTableCellWithSwitch * mySwitchCell = (MessageTableCellWithSwitch *)cell;
     SwitchView * mySwitch = (SwitchView *)mySwitchCell->accessoryView();
     mySwitch->setState(GlobalPreferences::sharedGlobalPreferences()->autocomplete());
   }
+#endif
 }
 
 }


### PR DESCRIPTION
Adding Flag HAS_CODE in apps/code/Makefile
To remove Code option in settings if the code app is not compiled.