### PR TITLE
Fix sys in Python toolbox

### DIFF
--- a/apps/code/python_toolbox.cpp
+++ b/apps/code/python_toolbox.cpp
@@ -403,7 +403,7 @@ const ToolboxMessageTree OsModuleChildren[] = {
   ToolboxMessageTree::Leaf(I18n::Message::PythonOsCommandListdir, I18n::Message::PythonOsListdir, false)
 };
 
-#ifdef MICROPY_PY_SYS
+#if MICROPY_PY_SYS
 const ToolboxMessageTree SysModuleChildren[] = {
   ToolboxMessageTree::Leaf(I18n::Message::PythonCommandImportSys, I18n::Message::PythonImportSys, false),
   ToolboxMessageTree::Leaf(I18n::Message::PythonCommandImportFromSys, I18n::Message::PythonImportSys, false),
@@ -429,7 +429,7 @@ const ToolboxMessageTree modulesChildren[] = {
   ToolboxMessageTree::Node(I18n::Message::KandinskyModule, KandinskyModuleChildren),
   ToolboxMessageTree::Node(I18n::Message::IonModule, IonModuleChildren),
   ToolboxMessageTree::Node(I18n::Message::OsModule, OsModuleChildren),
-#ifdef MICROPY_PY_SYS
+#if MICROPY_PY_SYS
   ToolboxMessageTree::Node(I18n::Message::SysModule, SysModuleChildren),
 #endif
   ToolboxMessageTree::Node(I18n::Message::TimeModule, TimeModuleChildren)


### PR DESCRIPTION
In #100, I updated MicroPython and I removed the sys module, unfortunately, I used `ifdef MICROPY_PY_SYS` instead of `#if MICROPY_PY_SYS` to check if the sys module is enabled in the toolbox so the sys module is always displayed