### PR TITLE
Fix cursor storage

### DIFF
--- a/apps/code/python_text_area.h
+++ b/apps/code/python_text_area.h
@@ -30,7 +30,7 @@ public:
    * - MiddleOfIdentifier is the cursor is in the middle of an identifier,
    * - No identifier otherwise.
    * The autocompletionLocation can be provided with autocompletionLocation, or
-   * retreived with autocompletionLocationBeginning and autocompletionLocationEnd. */
+   * retrieved with autocompletionLocationBeginning and autocompletionLocationEnd. */
   AutocompletionType autocompletionType(const char * autocompletionLocation = nullptr, const char ** autocompletionLocationBeginning = nullptr, const char ** autocompletionLocationEnd = nullptr) const;
   bool isAutocompleting() const { return m_contentView.isAutocompleting(); }
 protected:

--- a/apps/code/script.cpp
+++ b/apps/code/script.cpp
@@ -2,7 +2,7 @@
 #include "script_store.h"
 
 #if APP_SCRIPT_LOG
-#include<iostream>
+#include <iostream>
 #endif
 namespace Code {
 
@@ -72,13 +72,12 @@ uint8_t * StatusFromData(Script::Data d) {
   return const_cast<uint8_t *>(static_cast<const uint8_t *>(d.buffer));
 }
 
-uint8_t * Script::CursorPosition() {
+uint16_t * Script::CursorPosition() {
   assert(!isNull());
   Data d = value();
-  return StatusFromData(d) + StatusSize();
+  return (uint16_t *)StatusFromData(d) + StatusSize();
 }
-
-void Script::setCursorPosition(uint8_t position) {
+void Script::setCursorPosition(uint16_t position) {
   assert(!isNull());
   Data d = value();
   *CursorPosition() = position;

--- a/apps/code/script.cpp
+++ b/apps/code/script.cpp
@@ -75,7 +75,7 @@ uint8_t * StatusFromData(Script::Data d) {
 uint16_t * Script::CursorPosition() {
   assert(!isNull());
   Data d = value();
-  return (uint16_t *)StatusFromData(d) + StatusSize();
+  return (uint16_t *)(StatusFromData(d) + StatusSize());
 }
 void Script::setCursorPosition(uint16_t position) {
   assert(!isNull());

--- a/apps/code/script.h
+++ b/apps/code/script.h
@@ -23,9 +23,9 @@ namespace Code {
  * FetchedForVariableBoxBit is used to prevent circular importation problems,
  * such as scriptA importing scriptB, which imports scriptA. Once we get the
  * variables from a script to put them in the variable box, we switch the bit to
- * 1 and won't reload it afterwards. 
- * 
- * Cursor Position is one byte long and has the cursor position value*/
+ * 1 and won't reload it afterwards.
+ *
+ * Cursor Position is two bytes long and has the cursor position value */
 
 class Script : public Ion::Storage::Record {
 private:
@@ -35,7 +35,7 @@ private:
 
   // See the comment at the beginning of the file
   static constexpr size_t k_statusSize = 1;
-  static constexpr size_t k_cursorPositionSize = 1;
+  static constexpr size_t k_cursorPositionSize = 2;
 
 public:
   static constexpr int k_defaultScriptNameMaxSize = 6 + k_defaultScriptNameNumberMaxSize + 1;
@@ -54,8 +54,8 @@ public:
   void toggleAutoimportationStatus();
   const char * content() const;
   size_t contentSize() { return value().size - k_statusSize - k_cursorPositionSize; }
-  void setCursorPosition(uint8_t position);
-  uint8_t * CursorPosition();
+  void setCursorPosition(uint16_t position);
+  uint16_t * CursorPosition();
 
   /* Fetched status */
   bool fetchedFromConsole() const;

--- a/apps/code/script_store.cpp
+++ b/apps/code/script_store.cpp
@@ -51,7 +51,7 @@ void ScriptStore::clearConsoleFetchInformation() {
 }
 
 Script::ErrorStatus ScriptStore::addScriptFromTemplate(const ScriptTemplate * scriptTemplate) {
-  size_t valueSize = Script::StatusSize() + Script::CursorPositionSize() + strlen(scriptTemplate->content()) + 1; // (auto importation status + content fetched status) + scriptcontent size + null-terminating char
+  size_t valueSize = Script::StatusSize() + Script::CursorPositionSize() + strlen(scriptTemplate->content()) + 1; // (auto importation status + cursor position + content fetched status) + scriptcontent size + null-terminating char
   assert(Script::nameCompliant(scriptTemplate->name()));
   Script::ErrorStatus err = Ion::Storage::sharedStorage()->createRecordWithFullName(scriptTemplate->name(), scriptTemplate->value(), valueSize);
   assert(err != Script::ErrorStatus::NonCompliantName);

--- a/apps/code/script_store.h
+++ b/apps/code/script_store.h
@@ -49,9 +49,9 @@ private:
    * k_fullFreeSpaceSizeLimit, we consider the script store as full.
    * To be able to add a new empty record, the available space should at least
    * be able to store a Script with default name and its extension, the
-   * importation status (1 char), the default content "from math import *\n"
+   * importation status (1 char), the cursor (2 char), the default content "from math import *\n"
    * (20 char) and 10 char of free space. */
-  static constexpr int k_fullFreeSpaceSizeLimit = sizeof(Ion::Storage::record_size_t)+Script::k_defaultScriptNameMaxSize+k_scriptExtensionLength+1+20+10+1;
+  static constexpr int k_fullFreeSpaceSizeLimit = sizeof(Ion::Storage::record_size_t)+Script::k_defaultScriptNameMaxSize+k_scriptExtensionLength+1+20+10+2;
 };
 
 }

--- a/apps/code/script_template.cpp
+++ b/apps/code/script_template.cpp
@@ -2,7 +2,7 @@
 
 namespace Code {
 
-constexpr ScriptTemplate emptyScriptTemplate(".py", "\x01" "\x00" R"(from math import *
+constexpr ScriptTemplate emptyScriptTemplate(".py", "\x01" "\x00\x00" R"(from math import *
 )");
 
 

--- a/apps/code/test/variable_box_controller.cpp
+++ b/apps/code/test/variable_box_controller.cpp
@@ -63,7 +63,7 @@ QUIZ_CASE(variable_box_controller) {
   };
   // FIXME This test does not load imported variables for now
   assert_variables_are(
-      "\x01\x01 from math import *\nfroo=3",
+      "\x01\x01\x01 from math import *\nfroo=3",
       "fr",
       expectedVariables,
       sizeof(expectedVariables) / sizeof(const char *));

--- a/ion/include/ion/storage.h
+++ b/ion/include/ion/storage.h
@@ -122,8 +122,8 @@ public:
 
   // Useful
   static bool FullNameCompliant(const char * name);
-  
-  // User by Python OS module
+
+  // Used by Python OS module
   int numberOfRecords();
   Record recordAtIndex(int index);
 

--- a/poincare/include/poincare/evaluation.h
+++ b/poincare/include/poincare/evaluation.h
@@ -46,7 +46,7 @@ public:
     /* This function allows to convert Evaluation to derived Evaluation.
      *
      * We could have overriden the operator T(). However, even with the
-     * 'explicit' keyword (which prevents implicit casts), direct initilization
+     * 'explicit' keyword (which prevents implicit casts), direct initialization
      * are enable which can lead to weird code:
      * ie, you can write: 'Complex<float> a(2); MatrixComplex<float> b(a);'
      * */


### PR DESCRIPTION
This fix the cursor storage when the file have more than 256 characters : the cursor was saved on one byte and this is too little for more than 256 characters. This pull request fixes this.