### PR TITLE
Fix CI and replacement character

### DIFF
--- a/ion/test/events.cpp
+++ b/ion/test/events.cpp
@@ -18,7 +18,7 @@ QUIZ_CASE(ion_events_from_keyboard) {
 
   // Test some fallbacks
   quiz_assert(Event(Key::EXE, false, false, false) == EXE);
-  quiz_assert(Event(Key::EXE, true, false, false) == EXE);
+  quiz_assert(Event(Key::EXE, true, false, false) == ShiftEXE);
   quiz_assert(Event(Key::EXE, false, true, false) == EXE);
   quiz_assert(Event(Key::EXE, true, true, false) == EXE);
   quiz_assert(Event(Key::EXE, false, true, true) == EXE);

--- a/kandinsky/include/kandinsky/font.h
+++ b/kandinsky/include/kandinsky/font.h
@@ -61,7 +61,7 @@ public:
     CodePoint m_codePoint;
     GlyphIndex m_glyphIndex;
   };
-  static constexpr GlyphIndex IndexForReplacementCharacterCodePoint = 134;
+  static constexpr GlyphIndex IndexForReplacementCharacterCodePoint = 190;
   GlyphIndex indexForCodePoint(CodePoint c) const;
 
   void setGlyphGrayscalesForCodePoint(CodePoint codePoint, GlyphBuffer * glyphBuffer) const;

--- a/kandinsky/src/font.cpp
+++ b/kandinsky/src/font.cpp
@@ -155,7 +155,7 @@ KDFont::GlyphIndex KDFont::indexForCodePoint(CodePoint c) const {
     return endPair->glyphIndex();
   }
   NoMatchingGlyph:
-  assert(SimpleCodePoints[IndexForReplacementCharacterCodePoint] == 0xFFFD);
+  assert(ExtendedCodePoints[IndexForReplacementCharacterCodePoint] == 0xFFFD);
   return IndexForReplacementCharacterCodePoint;
 #endif
 }


### PR DESCRIPTION
This pull request fixes the CI and the replacement character. The CI crashed because e575ffc7ce3ce0b5c3091546cf0eab2d73ecec07 changed the behavior of shift + OK  : this is no longer returning OK as event. The replacement character was `≤` instead of `�` that made of an assert crash when a character wasn't supported. This pull request fixes that.