### PR TITLE
[apps/settings] Fix assert in about submenu when username enabled

### DIFF
--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -168,7 +168,6 @@ bool AboutController::hasUsernameCell() const {
 void AboutController::willDisplayCellForIndex(HighlightCell * cell, int index) {
   int i = index + (!hasUsernameCell());
   GenericSubController::willDisplayCellForIndex(cell, i);
-  assert(index >= 0 && index < k_totalNumberOfCell - (!hasUsernameCell()));
   if (m_messageTreeModel->childAtIndex(i)->label() == I18n::Message::Contributors) {
     MessageTableCellWithChevronAndMessage * myTextCell = (MessageTableCellWithChevronAndMessage *)cell;
     myTextCell->setSubtitle(I18n::Message::Default);

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -168,7 +168,7 @@ bool AboutController::hasUsernameCell() const {
 void AboutController::willDisplayCellForIndex(HighlightCell * cell, int index) {
   int i = index + (!hasUsernameCell());
   GenericSubController::willDisplayCellForIndex(cell, i);
-  assert(index >= 0 && index < k_totalNumberOfCell);
+  assert(index >= 0 && index < k_totalNumberOfCell - (!hasUsernameCell()));
   if (m_messageTreeModel->childAtIndex(i)->label() == I18n::Message::Contributors) {
     MessageTableCellWithChevronAndMessage * myTextCell = (MessageTableCellWithChevronAndMessage *)cell;
     myTextCell->setSubtitle(I18n::Message::Default);

--- a/apps/settings/sub_menu/about_controller.h
+++ b/apps/settings/sub_menu/about_controller.h
@@ -22,7 +22,7 @@ public:
   int typeAtLocation(int i, int j) override;
   int numberOfRows() const override;
 private:
-  constexpr static int k_totalNumberOfCell = 11;
+  constexpr static int k_totalNumberOfCell = 7;
   bool hasUsernameCell() const;
   ContributorsController m_contributorsController;
   MessageTableCellWithChevronAndMessage m_contributorsCell;

--- a/apps/settings/sub_menu/about_controller.h
+++ b/apps/settings/sub_menu/about_controller.h
@@ -22,7 +22,7 @@ public:
   int typeAtLocation(int i, int j) override;
   int numberOfRows() const override;
 private:
-  constexpr static int k_totalNumberOfCell = 7;
+  constexpr static int k_totalNumberOfCell = 8;
   bool hasUsernameCell() const;
   ContributorsController m_contributorsController;
   MessageTableCellWithChevronAndMessage m_contributorsCell;

--- a/apps/settings/sub_menu/about_controller.h
+++ b/apps/settings/sub_menu/about_controller.h
@@ -22,7 +22,7 @@ public:
   int typeAtLocation(int i, int j) override;
   int numberOfRows() const override;
 private:
-  constexpr static int k_totalNumberOfCell = 9;
+  constexpr static int k_totalNumberOfCell = 11;
   bool hasUsernameCell() const;
   ContributorsController m_contributorsController;
   MessageTableCellWithChevronAndMessage m_contributorsCell;


### PR DESCRIPTION
When we go in end of about submenu of settings in debug mode, the simulator crash because of the total number of cells, this pull request fixes that and fix also the same bug with username enabled (there are 2 cells more than `k_totalNumberOfCell`)