### PR TITLE
2 corrections of bugs about the battery level in the settings

### DIFF
--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -113,9 +113,8 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
         MessageTableCellWithBuffer * myCell = (MessageTableCellWithBuffer *)m_selectableTableView.selectedCell();
         char batteryLevel[5];
         if(strchr(myCell->accessoryText(), '%') == NULL) {
-
-            float voltage = (Ion::Battery::voltage() - 3.6) * 166;
-            if(voltage < 0.0) {
+          float voltage = (Ion::Battery::voltage() - 3.6) * 166;
+          if(voltage < 0.0) {
             myCell->setAccessoryText("0%"); // We cheat... => I don't agree : 0% is 0% not 1% x)
             return true;
           } else if (voltage >= 100.0) {

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -113,10 +113,16 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
         MessageTableCellWithBuffer * myCell = (MessageTableCellWithBuffer *)m_selectableTableView.selectedCell();
         char batteryLevel[5];
         if(strchr(myCell->accessoryText(), '%') == NULL){
-          int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
-          batteryLevel[batteryLen] = '%';
-          batteryLevel[batteryLen+1] = '\0';
-        }else{
+          #ifdef DEVICE
+            int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
+            batteryLevel[batteryLen] = '%';
+            batteryLevel[batteryLen+1] = '\0';
+          #else
+            batteryLevel[0] = '0';
+            batteryLevel[1] = '%';
+            batteryLevel[2] = '\0';
+          #endif
+        } else {
           int batteryLen = Poincare::Number::FloatNumber(Ion::Battery::voltage()).serialize(batteryLevel, 5, Poincare::Preferences::PrintFloatMode::Decimal, 3);
           batteryLevel[batteryLen] = 'V';
           batteryLevel[batteryLen+1] = '\0';

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -114,9 +114,15 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
         char batteryLevel[5];
         if(strchr(myCell->accessoryText(), '%') == NULL){
           #ifdef DEVICE
-            int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
-            batteryLevel[batteryLen] = '%';
-            batteryLevel[batteryLen+1] = '\0';
+            if(!Ion::Battery::isCharging() && Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)) <= 100) {
+              int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
+              batteryLevel[batteryLen] = '%';
+              batteryLevel[batteryLen+1] = '\0';
+            } else {
+                myCell->setAccessoryText("100%");
+              } 
+              return true;
+            }
           #else
             batteryLevel[0] = '0';
             batteryLevel[1] = '%';

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -113,21 +113,21 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
         MessageTableCellWithBuffer * myCell = (MessageTableCellWithBuffer *)m_selectableTableView.selectedCell();
         char batteryLevel[5];
         if(strchr(myCell->accessoryText(), '%') == NULL){
-          #ifdef DEVICE
-            if(!Ion::Battery::isCharging() && Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)) <= 100) {
+            if((int) ((Ion::Battery::voltage() - 3.6) * 166) < 0) {
+              batteryLevel[0] = '0';
+              batteryLevel[1] = '%';
+              batteryLevel[2] = '\0';
+            }
+            else
+            {
               int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
               batteryLevel[batteryLen] = '%';
               batteryLevel[batteryLen+1] = '\0';
-            } else {
-                myCell->setAccessoryText("100%");
-              } 
+            }
+            if(Ion::Battery::isCharging() && (int) ((Ion::Battery::voltage() - 3.6) * 166) >= 100) {
+              myCell->setAccessoryText("100%");
               return true;
             }
-          #else
-            batteryLevel[0] = '0';
-            batteryLevel[1] = '%';
-            batteryLevel[2] = '\0';
-          #endif
         } else {
           int batteryLen = Poincare::Number::FloatNumber(Ion::Battery::voltage()).serialize(batteryLevel, 5, Poincare::Preferences::PrintFloatMode::Decimal, 3);
           batteryLevel[batteryLen] = 'V';

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -112,23 +112,22 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
       if(childLabel == I18n::Message::Battery){
         MessageTableCellWithBuffer * myCell = (MessageTableCellWithBuffer *)m_selectableTableView.selectedCell();
         char batteryLevel[5];
-        if(strchr(myCell->accessoryText(), '%') == NULL){
-            if((int) ((Ion::Battery::voltage() - 3.6) * 166) < 0) {
-              batteryLevel[0] = '0';
-              batteryLevel[1] = '%';
-              batteryLevel[2] = '\0';
-            }
-            else
-            {
-              int batteryLen = Poincare::Integer((int) ((Ion::Battery::voltage() - 3.6) * 166)).serialize(batteryLevel, 5);
-              batteryLevel[batteryLen] = '%';
-              batteryLevel[batteryLen+1] = '\0';
-            }
-            if(Ion::Battery::isCharging() && (int) ((Ion::Battery::voltage() - 3.6) * 166) >= 100) {
-              myCell->setAccessoryText("100%");
-              return true;
-            }
-        } else {
+        if(strchr(myCell->accessoryText(), '%') == NULL) {
+
+            float voltage = (Ion::Battery::voltage() - 3.6) * 166;
+            if(voltage < 0.0) {
+            myCell->setAccessoryText("0%"); // We cheat... => I don't agree : 0% is 0% not 1% x)
+            return true;
+          } else if (voltage >= 100.0) {
+            myCell->setAccessoryText("100%");
+            return true;
+          } else {
+            int batteryLen = Poincare::Integer((int) voltage).serialize(batteryLevel, 5);
+            batteryLevel[batteryLen] = '%';
+            batteryLevel[batteryLen+1] = '\0';
+          }
+        }
+        else {
           int batteryLen = Poincare::Number::FloatNumber(Ion::Battery::voltage()).serialize(batteryLevel, 5, Poincare::Preferences::PrintFloatMode::Decimal, 3);
           batteryLevel[batteryLen] = 'V';
           batteryLevel[batteryLen+1] = '\0';

--- a/apps/settings/sub_menu/about_controller.cpp
+++ b/apps/settings/sub_menu/about_controller.cpp
@@ -115,7 +115,7 @@ bool AboutController::handleEvent(Ion::Events::Event event) {
         if(strchr(myCell->accessoryText(), '%') == NULL) {
           float voltage = (Ion::Battery::voltage() - 3.6) * 166;
           if(voltage < 0.0) {
-            myCell->setAccessoryText("0%"); // We cheat... => I don't agree : 0% is 0% not 1% x)
+            myCell->setAccessoryText("1%"); // We cheat...
             return true;
           } else if (voltage >= 100.0) {
             myCell->setAccessoryText("100%");


### PR DESCRIPTION
First bug : 
- when you use the simulator and go in the about section, you see that the battery level (in %) is -537% or something like that, with my patch it is now 0%

Second bug : 
- when you plug your calculator, the battery level is > 100% obviously but it is not necessary to show this "fake" value I think. So the battery level when the calculator is plugged is blocked to 100% whereas the battery voltage is the real voltage.

Bye :p