### PR TITLE
[ion] Fix win11 build for n0110 (#182)

### DIFF
--- a/ion/src/device/n0110/flash.ld
+++ b/ion/src/device/n0110/flash.ld
@@ -236,6 +236,8 @@ SECTIONS {
     . = ALIGN(4);
     *(.rodata._ZN3Ion6Device13ExternalFlash*)
     /* 'start' dependencies */
+    *(.rodata._ZN3Ion6Device8Keyboard6ConfigL10ColumnGPIOE*)
+    *(.rodata._ZN3Ion6Device8Keyboard6ConfigL7RowGPIOE*)
     *(.rodata._ZN3Ion6Device4RegsL5GPIOAE)
     *(.rodata._ZN3Ion6Device4RegsL5GPIOBE)
     *(.rodata._ZN3Ion6Device3LED6ConfigL7RGBPinsE)


### PR DESCRIPTION
Allow Windows 11 users to build Upsilon for n0110

* Update ion/…/n0110/flash.ld

Co-authored-by : devdl11