### PR TITLE
[apps/shared/interval] Pass parameter by const *

### DIFF
--- a/apps/shared/interval.cpp
+++ b/apps/shared/interval.cpp
@@ -23,7 +23,7 @@ void Interval::deleteElementAtIndex(int index) {
   m_numberOfElements--;
 }
 
-bool Interval::hasSameParameters(IntervalParameters parameters) {
+bool Interval::hasSameParameters(const IntervalParameters &parameters) {
   return (m_parameters.start() == parameters.start() && m_parameters.end() == parameters.end() && m_parameters.step() == parameters.step());
 }
 

--- a/apps/shared/interval.h
+++ b/apps/shared/interval.h
@@ -23,10 +23,10 @@ public:
     double m_end;
     double m_step;
   };
-  bool hasSameParameters(IntervalParameters parameters);
+  bool hasSameParameters(const IntervalParameters &parameters);
   double element(int i);
   IntervalParameters * parameters() { return &m_parameters; }
-  void setParameters(IntervalParameters parameters) { m_parameters = parameters; }
+  void setParameters(const IntervalParameters &parameters) { m_parameters = parameters; }
   void setElement(int i, double f);
   void forceRecompute(){ m_needCompute = true;}
   void reset();


### PR DESCRIPTION
In apps/shared/interval.{cpp,h}, there are two function calls that have a parameter passed by value. It could be passed as a const reference which is usually faster and recommended in C++.
I have tested this on the calculator and everything seems in order. I'm making this PR to see if it'll change the RAM/flash usage and/or performance; it should theoretically, but I don't know if it will be noticeable.