### PR TITLE
Fix Readme Links

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -26,7 +26,7 @@ Upsilon est un fork d'Omega, un fork d'Epsilon, l'OS de Numworks tournant sur le
 ## Installation
 
 ### Site web
-Rendez-vous sur le [site d'Upsilon](https://lolocomotive.github.io/Upsilon-website) à la section "Installer".
+Rendez-vous sur le [site d'Upsilon](https://getupsilon.web.app/) à la section "Installer".
 Si votre calculatrice est reconnue, qu'elle contient une version d'Epsilon inférieure à 16 et que votre navigateur accepte WebUSB, la page vous proposera d'installer Upsilon.  
 Ne débranchez votre calculatrice qu'une fois l'installation terminée.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Upsilon is a fork of Omega, an user-made OS that runs on the Numworks calculator
 
 ### Installer
 
-Go to the [Upsilon website](https://lolocomotive.github.io/Upsilon-website) to the "Install" section.
+Go to the [Upsilon website](https://getupsilon.web.app/) to the "Install" section.
 If your calculator is recognized, contains a version of Epsilon lower than 16 and your browser accepts WebUSB, the page will suggest you to install Upsilon.
 Do not disconnect your calculator until the installation is complete.
 


### PR DESCRIPTION
The links for installing upsilon on both the english and french readmes direct to a redirect page. I am just updating the links to go directly instead.