### PR TITLE
[bootloader/menu] Fix typo

### DIFF
--- a/bootloader/interface/src/menu.h
+++ b/bootloader/interface/src/menu.h
@@ -9,10 +9,10 @@ namespace Bootloader {
   class Menu {
     public:
       Menu() : Menu(KDColorBlack, KDColorWhite, Messages::mainTitle) { };
-      Menu(KDColor forground, KDColor background, const char * title) : Menu(forground, background, title,  nullptr) {};
-      Menu(KDColor forground, KDColor background, const char * title, const char * bottom) : Menu(forground, background, title, bottom, false) {};
-      Menu(KDColor forground, KDColor background, const char * title, const char * bottom, bool centerY) :  Menu(forground, background, title, bottom, centerY, k_columns_margin) {};
-      Menu(KDColor forground, KDColor background, const char * title, const char * bottom, bool centerY, int margin) : m_columns(), m_defaultColumns(), m_slotColumns(), m_background(background), m_title(title), m_foreground(forground), m_bottom(bottom), m_centerY(centerY), m_forced_exit(false), m_margin(margin) {
+      Menu(KDColor foreground, KDColor background, const char * title) : Menu(foreground, background, title,  nullptr) {};
+      Menu(KDColor foreground, KDColor background, const char * title, const char * bottom) : Menu(foreground, background, title, bottom, false) {};
+      Menu(KDColor foreground, KDColor background, const char * title, const char * bottom, bool centerY) :  Menu(foreground, background, title, bottom, centerY, k_columns_margin) {};
+      Menu(KDColor foreground, KDColor background, const char * title, const char * bottom, bool centerY, int margin) : m_columns(), m_defaultColumns(), m_slotColumns(), m_background(background), m_title(title), m_foreground(foreground), m_bottom(bottom), m_centerY(centerY), m_forced_exit(false), m_margin(margin) {
         setup();
       }
       static const int k_columns_margin = 5;


### PR DESCRIPTION
"forground" should've been "foreground." No impact to functionality.