### PR TITLE
[LD] Fixed warning about different array declaration

### DIFF
--- a/apps/code/toolbox_ion_keys.cpp
+++ b/apps/code/toolbox_ion_keys.cpp
@@ -6,7 +6,7 @@ extern "C" {
 #include <py/obj.h>
 #include <py/objfun.h>
 }
-extern "C" const mp_rom_map_elem_t modion_module_globals_table[52];
+extern "C" const mp_rom_map_elem_t modion_module_globals_table[55];
 
 namespace Code {
 ToolboxIonKeys::ToolboxIonKeys() :


### PR DESCRIPTION
The size declared in toolbox_ion_keys.cpp for the modion_module_globals_table array was different that the defined array in micropython