### PR TITLE
[apps/external] Add python external app support

### DIFF
--- a/apps/external/Makefile
+++ b/apps/external/Makefile
@@ -3,6 +3,7 @@ ifdef HOME_DISPLAY_EXTERNALS
 app_external_src = $(addprefix apps/external/,\
 	extapp_api.cpp \
 	archive.cpp \
+	execution_environment.cpp \
 )
 
 $(eval $(call depends_on_image,apps/home/controller.cpp,apps/external/external_icon.png))
@@ -18,6 +19,7 @@ app_external_src = $(addprefix apps/external/,\
 	archive.cpp \
 	main_controller.cpp \
 	pointer_text_table_cell.cpp \
+	execution_environment.cpp \
 )
 
 $(eval $(call depends_on_image,apps/external/app.cpp,apps/external/external_icon.png))

--- a/apps/external/archive.h
+++ b/apps/external/archive.h
@@ -23,6 +23,7 @@ size_t numberOfFiles();
 size_t numberOfExecutables();
 bool executableAtIndex(size_t index, File &entry);
 uint32_t executeFile(const char *name, void * heap, const uint32_t heapSize);
+uint32_t executePython(const char *name, void * heap, const uint32_t heapSize);
 
 }
 }

--- a/apps/external/execution_environment.cpp
+++ b/apps/external/execution_environment.cpp
@@ -1,0 +1,36 @@
+#include "execution_environment.h"
+#include <apps/home/app.h>
+#include <string.h>
+
+void ExternalExecutionEnvironment::printText(const char * text, size_t length) {
+  // TODO: Store the text somewhere
+}
+
+// TODO: Use a namespace
+
+bool execute_input(ExternalExecutionEnvironment env, const char * filename) {
+  // Use the following syntax to execute a Python script:
+  // exec(open("filename").read())
+  const char * pythonCodeStart = "exec(open(\"";
+  const char * pythonCodeEnd = "\").read())";
+  // Initialize the buffer to store the python code (size = 50)
+  char pythonCode[50];
+  // Add the start of the python code in the buffer (until the file name)
+  strlcpy(pythonCode, pythonCodeStart, sizeof(pythonCode));
+  // Add the file name in the buffer
+  strlcpy(pythonCode + strlen(pythonCode), filename, sizeof(pythonCode) - strlen(pythonCode));
+  // Add the end of the python code in the buffer
+  strlcpy(pythonCode + strlen(pythonCode), pythonCodeEnd, sizeof(pythonCode) - strlen(pythonCode));
+  // Execute the python code
+  bool executionResult = env.runCode(pythonCode);
+  return executionResult;
+}
+
+ExternalExecutionEnvironment init_environnement(void * heap, const uint32_t heapSize) {
+  MicroPython::init((uint32_t *)heap, (uint32_t *)heap + heapSize);
+  return ExternalExecutionEnvironment();
+}
+
+void deinit_environment() {
+  MicroPython::deinit();
+}

--- a/apps/external/execution_environment.h
+++ b/apps/external/execution_environment.h
@@ -1,0 +1,17 @@
+#include <python/port/port.h>
+#include <apps/code/app.h>
+
+class ExternalExecutionEnvironment : public MicroPython::ExecutionEnvironment {
+public:
+  ExternalExecutionEnvironment() : m_printTextIndex(0) {}
+  void printText(const char * text, size_t length) override;
+  const char * lastPrintedText() const { return m_printTextBuffer; }
+private:
+  static constexpr size_t k_maxPrintedTextSize = 256;
+  char m_printTextBuffer[k_maxPrintedTextSize];
+  size_t m_printTextIndex;
+};
+
+ExternalExecutionEnvironment init_environnement(void * heap, const uint32_t heapSize);
+void deinit_environment();
+bool execute_input(ExternalExecutionEnvironment env, const char * filename);

--- a/python/port/mod/kandinsky/modkandinsky.cpp
+++ b/python/port/mod/kandinsky/modkandinsky.cpp
@@ -63,8 +63,13 @@ mp_obj_t modkandinsky_draw_string(size_t n_args, const mp_obj_t * args) {
   KDColor textColor = (n_args >= 4) ? MicroPython::Color::Parse(args[3]) : Palette::PrimaryText;
   KDColor backgroundColor = (n_args >= 5) ? MicroPython::Color::Parse(args[4]) : Palette::HomeBackground;
   const KDFont * font = (n_args >= 6) ? ((mp_obj_is_true(args[5])) ? KDFont::SmallFont : KDFont::LargeFont) : KDFont::LargeFont;
-  MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
-  KDIonContext::sharedContext()->drawString(text, point, font, textColor, backgroundColor);
+  // Get tbe context and draw the string.
+  KDIonContext * ctx = KDIonContext::sharedContext();
+  ctx->setClippingRect(KDRect(0, 0, 320, 240));
+  ctx->setOrigin(KDPoint(0, 0));
+  ctx->drawString(text, point, font, KDColor::RGB16(textColor), KDColor::RGB16(backgroundColor));
+  // MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
+  // KDIonContext::sharedContext()->drawString(text, point, font, textColor, backgroundColor);
   return mp_const_none;
 }
 
@@ -111,8 +116,15 @@ mp_obj_t modkandinsky_fill_rect(size_t n_args, const mp_obj_t * args) {
   }
   KDRect rect(x, y, width, height);
   KDColor color = MicroPython::Color::Parse(args[4]);
-  MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
-  KDIonContext::sharedContext()->fillRect(rect, color);
+  // TODO: Get if the actual application is Python or not.
+  // If it isn't, we need to call directly the Ion fillRect function.
+  // If it is, we call the displaySandbox function, which will hide the console
+  // and switch to another mode.
+  // KDIonContext::sharedContext()->fillRect(rect, color);
+  Ion::Display::pushRectUniform(rect, color);
+  // KDColor color = KDColorBlue;
+  // MicroPython::ExecutionEnvironment::currentExecutionEnvironment()->displaySandbox();
+  // KDIonContext::sharedContext()->fillRect(rect, color);
   return mp_const_none;
 }
 


### PR DESCRIPTION
This pull request will add Python external apps.
It's work in progress :

- [ ] Use namespaces for Python env
- [ ] Add console view (for errors, prints and inputs)
- [ ] Use Kandinsky to display (fix python app's Kandinsky)
- [ ] Add menu to execute or copy to RAM
- [ ] Execute using a better way than `exec(open('filename.py','r').read())` (MicroPython's runcode)