### PR TITLE
Set Onboarding flash by default on README

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -274,7 +274,7 @@ make MODEL=n0100 EPSILON_I18N=en OMEGA_USERNAME="{Votre nom, maximum 15 caractè
 Maintenant, lancez soit:
 
 ```bash
-make MODEL=n0100 epsilon_flash
+make MODEL=n0100 epsilon.onboarding_flash
 ```
 
 pour directement flasher la calculatrice après avoir appuyé simultanément sur `reset` et `6` et avoir branché la calculatrice à l'ordinateur.
@@ -311,7 +311,7 @@ make OMEGA_USERNAME="{Votre nom, max 15 caractères}" -j4
 Ensuite lancez soit:
 
 ```bash
-make epsilon.A_flash
+make epsilon.onboarding.A_flash
 ```
 
 pour flasher le slot actuel ou pour flasher par le flasher du booloader avec RESET, puis 4 (flash) et 1 (flash slots) pour flasher n'importe quel slot.
@@ -341,7 +341,7 @@ make MODEL=n0110 OMEGA_USERNAME="{Votre nom, max 15 caractères}" -j4
 Ensuite lancez soit:
 
 ```bash
-make MODEL=n0110 epsilon_flash
+make MODEL=n0110 epsilon.onboarding_flash
 ```
 
 pour directement flasher la calculatrice après avoir appuyé simultanément sur `RESET` et `6` et avoir branché la calculatrice à l'ordinateur.

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ make MODEL=n0100 EPSILON_I18N=en OMEGA_USERNAME="{Your name, max 15 characters}"
 Now, run either:
 
 ```bash
-make MODEL=n0100 epsilon_flash
+make MODEL=n0100 epsilon.onboarding_flash
 ```
 
 to directly flash the calculator after pressing simultaneously `reset` and `6` buttons and plugging in.
@@ -307,7 +307,7 @@ make OMEGA_USERNAME="{Your name, max 15 characters}" -j4
 Now, run either:
 
 ```bash
-make epsilon.A_flash
+make epsilon.onboarding.A_flash
 ```
 
 to directly flash the calculator into the current slot, or thought bootloader's slot flasher with RESET, then 4 (flash), and 1 (flash slots) for other slots.
@@ -336,7 +336,7 @@ make MODEL=n0110 OMEGA_USERNAME="{Your name, max 15 characters}" -j4
 Now, run either:
 
 ```bash
-make MODEL=n0110 epsilon_flash
+make MODEL=n0110 epsilon.onboarding_flash
 ```
 
 to directly flash the calculator after pressing simultaneously `reset` and `6` buttons and plugging in.


### PR DESCRIPTION
I tried to flash with `epsilon.onboarding_flash` instead of `epsilon_flash` and I got the onboarding.
So for convenience I decided to change the commands in README.