### PR TITLE
[CI] Fix Web CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -220,7 +220,7 @@ jobs:
   web:
     runs-on: ubuntu-latest
     steps:
-      - uses: numworks/setup-emscripten@v1
+      - uses: numworks/setup-emscripten@master
         with:
           sdk: 1.40.1
       - uses: actions/checkout@v2


### PR DESCRIPTION
Branch `v1` of [`numworks/setup-emscripten` ](https://github.com/numworks/setup-emscripten) has been deleted. This pull request moves it to master.