### PR TITLE
[apps/home] Quick select for apps using numbers 

### DIFF
--- a/apps/home/Makefile
+++ b/apps/home/Makefile
@@ -16,6 +16,8 @@ i18n_files += $(call i18n_without_universal_for,home/base)
 # findable this way
 SFLAGS += -I$(BUILD_DIR)
 
+CXXFLAGS = -DAPPS_CONTAINER_SNAPSHOT_COUNT=$(snapshots_count)
+
 apps_layout = apps/home/apps_layout.csv
 
 $(eval $(call rule_for, \

--- a/apps/home/Makefile
+++ b/apps/home/Makefile
@@ -16,8 +16,6 @@ i18n_files += $(call i18n_without_universal_for,home/base)
 # findable this way
 SFLAGS += -I$(BUILD_DIR)
 
-CXXFLAGS = -DAPPS_CONTAINER_SNAPSHOT_COUNT=$(snapshots_count)
-
 apps_layout = apps/home/apps_layout.csv
 
 $(eval $(call rule_for, \

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -15,6 +15,10 @@ extern "C" {
 #include <string.h>
 #endif
 
+#ifndef APPS_CONTAINER_SNAPSHOT_COUNT
+#error Missing snapshot count
+#endif
+
 namespace Home {
 
 Controller::ContentView::ContentView(Controller * controller, SelectableTableViewDataSource * selectionDataSource) :
@@ -75,7 +79,7 @@ Controller::Controller(Responder * parentResponder, SelectableTableViewDataSourc
 
   m_view.backgroundView()->setDefaultColor(Palette::HomeBackground);
 
-      
+
 #ifdef HOME_DISPLAY_EXTERNALS
     int index = External::Archive::indexFromName("wallpaper.obm");
     if(index > -1) {
@@ -85,6 +89,13 @@ Controller::Controller(Responder * parentResponder, SelectableTableViewDataSourc
     }
 #endif
 }
+
+static constexpr Ion::Events::Event home_fast_navigation_events[] = {
+    Ion::Events::Seven, Ion::Events::Eight, Ion::Events::Nine,
+    Ion::Events::Four, Ion::Events::Five, Ion::Events::Six,
+    Ion::Events::One, Ion::Events::Two, Ion::Events::Three,
+    Ion::Events::Zero, Ion::Events::Dot, Ion::Events::EE
+};
 
 bool Controller::handleEvent(Ion::Events::Event event) {
   if (event == Ion::Events::OK || event == Ion::Events::EXE) {
@@ -141,6 +152,21 @@ bool Controller::handleEvent(Ion::Events::Event event) {
   }
   if (event == Ion::Events::Left && selectionDataSource()->selectedRow() > 0) {
     return m_view.selectableTableView()->selectCellAtLocation(numberOfColumns() - 1, selectionDataSource()->selectedRow() - 1);
+  }
+
+  // Handle fast home navigation
+  for(int i = 0; i < std::min((int) (sizeof(home_fast_navigation_events) / sizeof(Ion::Events::Event)), APPS_CONTAINER_SNAPSHOT_COUNT); i++) {
+    if (event == home_fast_navigation_events[i]) {
+      int row = i / k_numberOfColumns;
+      int column = i % k_numberOfColumns;
+      // Get if app is already selected
+      if (selectionDataSource()->selectedRow() == row && selectionDataSource()->selectedColumn() == column) {
+        // If app is already selected, launch it
+        return handleEvent(Ion::Events::OK);
+      }
+      // Else, select the app
+      return m_view.selectableTableView()->selectCellAtLocation(column, row);
+    }
   }
 
   return false;

--- a/apps/home/controller.cpp
+++ b/apps/home/controller.cpp
@@ -15,10 +15,6 @@ extern "C" {
 #include <string.h>
 #endif
 
-#ifndef APPS_CONTAINER_SNAPSHOT_COUNT
-#error Missing snapshot count
-#endif
-
 namespace Home {
 
 Controller::ContentView::ContentView(Controller * controller, SelectableTableViewDataSource * selectionDataSource) :
@@ -155,7 +151,7 @@ bool Controller::handleEvent(Ion::Events::Event event) {
   }
 
   // Handle fast home navigation
-  for(int i = 0; i < std::min((int) (sizeof(home_fast_navigation_events) / sizeof(Ion::Events::Event)), APPS_CONTAINER_SNAPSHOT_COUNT); i++) {
+  for(int i = 0; i < std::min((int) (sizeof(home_fast_navigation_events) / sizeof(Ion::Events::Event)), this->numberOfIcons()); i++) {
     if (event == home_fast_navigation_events[i]) {
       int row = i / k_numberOfColumns;
       int column = i % k_numberOfColumns;


### PR DESCRIPTION
The pull request adds number usage on Home menu to select app. Pressing the app's number on herself will open it. e.g., pressing 2 on home menu will select it and pressing it another time will open it.