### PR TITLE
[Simulator] Don't resize canvas to 0x0

### DIFF
--- a/apps/code/script_template.h
+++ b/apps/code/script_template.h
@@ -10,7 +10,7 @@ public:
   constexpr ScriptTemplate(const char * name, const char * value) : m_name(name), m_value(value) {}
   static const ScriptTemplate * Empty();
   const char * name() const { return m_name; }
-  const char * content() const { return m_value;}
+  const char * content() const { return m_value + Script::StatusSize(); }
   const char * value() const { return m_value; }
 private:
   const char * m_name;

--- a/ion/src/simulator/external/sdl/src/video/emscripten/SDL_emscriptenvideo.c
+++ b/ion/src/simulator/external/sdl/src/video/emscripten/SDL_emscriptenvideo.c
@@ -268,9 +268,6 @@ Emscripten_DestroyWindow(_THIS, SDL_Window * window)
             data->egl_surface = EGL_NO_SURFACE;
         }
 #endif
-
-        /* We can't destroy the canvas, so resize it to zero instead */
-        emscripten_set_canvas_element_size(data->canvas_id, 0, 0);
         SDL_free(data->canvas_id);
 
         SDL_free(window->driverdata);


### PR DESCRIPTION
This solves problems when trying to restart the simulator, which is necessary for the Upsilon workshop.