### PR TITLE
little fix with key EE

### DIFF
--- a/apps/apps_container.cpp
+++ b/apps/apps_container.cpp
@@ -273,9 +273,9 @@ bool AppsContainer::processEvent(Ion::Events::Event event) {
     }
   }
 
-  // Add EE shortcut to go to the settings (app number 12)
+  // Add EE shortcut to go to the settings
   if (event == Ion::Events::EE) {
-    switchTo(appSnapshotAtIndex(12));
+    switchTo(appSnapshotAtIndex(APPS_CONTAINER_SNAPSHOT_COUNT));
     return true;
   }
 


### PR DESCRIPTION
The calculator crash when this key is pressed and if an app like rpn, reader, or other, is not present so will use the constant APPS_CONTAINER_SNAPSHOT_COUNT to know index of settings.

**Note :** I haven't tested the case where it could always select the last of apps, if there are external ones. I don't know if this variable also counts external apps, but I see it used above, so why not use it.

**EDIT:** I tested this case and is work perfectly, the key always open settings even 1 or more apps is not present. 😉