### PR TITLE
[NSpire Simulator] Fix framebuffer in nspire port

### DIFF
--- a/ion/src/simulator/nspire/display.cpp
+++ b/ion/src/simulator/nspire/display.cpp
@@ -21,25 +21,10 @@ void quit() {
 }
 
 void draw() {
-  // copy framebuffer
-  const short unsigned int * ptr = (const short unsigned int *) Ion::Simulator::Framebuffer::address();
-  Gc * gcptr = get_gc();
-  for (int j = 0; j < LCD_HEIGHT_PX; ++j) {
-    for (int i = 0; i < LCD_WIDTH_PX;){
-      int c = *ptr;
-      int k = 1;
-      for (; k+i < LCD_WIDTH_PX; ++k) {
-      	if (ptr[k]!=c) {
-	        break;
-        }
-      }
-      gui_gc_setColor(*gcptr,c_rgb565to888(c));
-      gui_gc_drawRect(*gcptr,i,j,k-1,0);
-      ptr += k;
-      i += k;
-    }
-  }
-  sync_screen();
+  unsigned short * ionFramebuffer = (unsigned short *) Ion::Simulator::Framebuffer::address();
+  // we specify the screen fmt here because the "native" fmt varies between calculator revisions
+  // some default to a 240x320 specification, which results in a 90-degree framebuffer rotation and other terribleness.
+  lcd_blit(ionFramebuffer,SCR_320x240_565);
 }
 
 }

--- a/ion/src/simulator/nspire/k_csdk.c
+++ b/ion/src/simulator/nspire/k_csdk.c
@@ -584,10 +584,10 @@ void statusflags(){
     else
       msg="";
   }
-  os_fill_rect(0,0,LCD_WIDTH_PX,16,SDK_BLACK);
-  os_draw_string_medium(225,-STATUS_AREA_PX,statuscolor,SDK_BLACK,msg,false);
-  os_draw_string_medium(160,-STATUS_AREA_PX,statuscolor,SDK_BLACK,os_get_angle_unit()?" rad ":" deg ",false);  
-  display_time();
+  // os_fill_rect(0,0,LCD_WIDTH_PX,16,SDK_BLACK);
+  // os_draw_string_medium(225,-STATUS_AREA_PX,statuscolor,SDK_BLACK,msg,false);
+  // os_draw_string_medium(160,-STATUS_AREA_PX,statuscolor,SDK_BLACK,os_get_angle_unit()?" rad ":" deg ",false);  
+  // display_time();
 }
 void statusline(int mode){
   statusflags();
@@ -617,7 +617,7 @@ void statusline(int mode){
 #include "k_defs.h"
 
 void sdk_init(void){
-  lcd_init(lcd_type()); // clrscr();
+  lcd_init(lcd_type());
 }
 
 void sdk_end(void){
@@ -993,6 +993,7 @@ int nspire_shift=0;
 int nspire_ctrl=0;
 int nspire_select=false;
 void statusline(int mode){
+  return; //DON'T DO ANYTHING YOU IDIOT
   char *msg=0;
   if (nspire_ctrl){
     if (nspire_shift)

--- a/ion/src/simulator/nspire/k_csdk.c
+++ b/ion/src/simulator/nspire/k_csdk.c
@@ -584,10 +584,10 @@ void statusflags(){
     else
       msg="";
   }
-  // os_fill_rect(0,0,LCD_WIDTH_PX,16,SDK_BLACK);
-  // os_draw_string_medium(225,-STATUS_AREA_PX,statuscolor,SDK_BLACK,msg,false);
-  // os_draw_string_medium(160,-STATUS_AREA_PX,statuscolor,SDK_BLACK,os_get_angle_unit()?" rad ":" deg ",false);  
-  // display_time();
+  os_fill_rect(0,0,LCD_WIDTH_PX,16,SDK_BLACK);
+  os_draw_string_medium(225,-STATUS_AREA_PX,statuscolor,SDK_BLACK,msg,false);
+  os_draw_string_medium(160,-STATUS_AREA_PX,statuscolor,SDK_BLACK,os_get_angle_unit()?" rad ":" deg ",false);  
+  display_time();
 }
 void statusline(int mode){
   statusflags();
@@ -993,7 +993,7 @@ int nspire_shift=0;
 int nspire_ctrl=0;
 int nspire_select=false;
 void statusline(int mode){
-  return; //DON'T DO ANYTHING YOU IDIOT
+  return; //this is broken for our purposes and it honestly doesn't matter enough to fix.
   char *msg=0;
   if (nspire_ctrl){
     if (nspire_shift)

--- a/ion/src/simulator/nspire/keyboard.cpp
+++ b/ion/src/simulator/nspire/keyboard.cpp
@@ -261,6 +261,9 @@ State scan() {
       return state;
     }
   }
+  if (isKeyPressed(KEY_NSPIRE_TENX)){
+      exit(0);
+  }
   return state;
 }
 

--- a/ion/src/simulator/nspire/main.cpp
+++ b/ion/src/simulator/nspire/main.cpp
@@ -25,7 +25,7 @@ extern "C" {
   int calculator=4; // -1 means OS not checked, 0 unknown, 1 cg50 or 90, 2 emu 50 or 90, 3 other
 
   int main() {
-    sdk_init();
+    sdk_init(); //this calls the lcd init functions from behind the scenes
     Ion::Simulator::Main::init();
     ion_main(0, NULL);
     Ion::Simulator::Main::quit();
@@ -61,35 +61,6 @@ void refresh() {
 
 void quit() {
   Ion::Simulator::Display::quit();
-}
-
-void runPowerOffSafe(void (*powerOffSafeFunction)(), bool prepareVRAM) {
-  // somewhat OFF by setting LCD to 0
-  unsigned NSPIRE_CONTRAST_ADDR=is_cx2?0x90130014:0x900f0020;
-  unsigned oldval=*(volatile unsigned *)NSPIRE_CONTRAST_ADDR,oldval2;
-  if (is_cx2){
-    oldval2=*(volatile unsigned *) (NSPIRE_CONTRAST_ADDR+4);
-    *(volatile unsigned *) (NSPIRE_CONTRAST_ADDR+4)=0xffff;
-  }
-  *(volatile unsigned *)NSPIRE_CONTRAST_ADDR=is_cx2?0xffff:0x100;
-  static volatile uint32_t *lcd_controller = (volatile uint32_t*) 0xC0000000;
-  lcd_controller[6] &= ~(0b1 << 11);
-  loopsleep(20);
-  lcd_controller[6] &= ~ 0b1; 
-  unsigned NSPIRE_RTC_ADDR=0x90090000;
-  unsigned offtime=* (volatile unsigned *) NSPIRE_RTC_ADDR;
-  for (int n=0;!on_key_pressed();++n){
-    loopsleep(100);
-    idle();
-  }
-  lcd_controller[6] |= 0b1;
-  loopsleep(20);
-  lcd_controller[6]|= 0b1 << 11;
-  if (is_cx2)
-    *(volatile unsigned *)(NSPIRE_CONTRAST_ADDR+4)=oldval2;
-  *(volatile unsigned *)NSPIRE_CONTRAST_ADDR=oldval;
-  sync_screen();
-
 }
 
 }

--- a/ion/src/simulator/nspire/main.h
+++ b/ion/src/simulator/nspire/main.h
@@ -11,8 +11,6 @@ void quit();
 void setNeedsRefresh();
 void refresh();
 
-void runPowerOffSafe(void (*powerOffSafeFunction)(), bool prepareVRAM);
-
 }
 }
 }

--- a/ion/src/simulator/nspire/power.cpp
+++ b/ion/src/simulator/nspire/power.cpp
@@ -11,12 +11,16 @@ void powerOff(void){
 namespace Ion {
 namespace Power {
 
+//NOTE: These should probably be reimplemented at some point
+//the prior version was a janky mess that flickered a ton on wake
+//and was generally awfulness.
+
 void suspend(bool checkIfOnOffKeyReleased) {
-  Simulator::Main::runPowerOffSafe(powerOff, true);
+ // Simulator::Main::runPowerOffSafe(powerOff, true);
 }
 
 void standby() {
-  Simulator::Main::runPowerOffSafe(powerOff, true);
+ // Simulator::Main::runPowerOffSafe(powerOff, true);
 }
 
 }


### PR DESCRIPTION
Resolves the issue brought up in UpsilonNumworks/Upsilon#339 (and therefore closes #339 )

The issue ultimately boils down to incorrectly handling the fact that some calculators use a different framebuffer implementation under the hood that is not compatible with the assumptions that were being made.

Also makes the framebuffer copy more efficient - direct passing of the buffer via `lcd_blit` instead of the loop-through-and-draw-1x1-rectangles algorithm being used before.