### PR TITLE
[build] update apps_layout.csv from EPSILON_APPS flag in make command

### DIFF
--- a/apps/home/Makefile
+++ b/apps/home/Makefile
@@ -17,12 +17,13 @@ i18n_files += $(call i18n_without_universal_for,home/base)
 SFLAGS += -I$(BUILD_DIR)
 
 apps_layout = apps/home/apps_layout.csv
+apps_layout_list = $(foreach i, $${EPSILON_APPS}, $(if $(filter external, $(i)),,"$(i),"))
 
 $(eval $(call rule_for, \
   APPS_LAYOUT, \
   apps/home/apps_layout.cpp, \
   , \
-  $$(PYTHON) apps/home/apps_layout.py --layouts $(apps_layout) --header $$(subst .cpp,.h,$$@) --implementation $$@ --apps $$(EPSILON_APPS), \
+  $$(PYTHON) apps/home/apps_layout.py --layouts $(apps_layout) --header $$(subst .cpp,.h,$$@) --implementation $$@ --apps $$(EPSILON_APPS) --apps_layout $(apps_layout_list), \
   global \
 ))
 

--- a/apps/home/apps_layout.py
+++ b/apps/home/apps_layout.py
@@ -12,8 +12,17 @@ parser.add_argument('--header', help='the .h file to generate')
 parser.add_argument('--implementation', help='the .cpp file to generate')
 parser.add_argument('--apps', nargs='+', help='apps that are actually compiled')
 parser.add_argument('--layouts', help='the apps_layout.csv file')
+parser.add_argument('--apps_layout', help='the apps_layout from the make command')
 
 args = parser.parse_args()
+
+with io.open(args.layouts, "w", encoding="utf-8") as f:
+    ordered = args.apps_layout.split()
+    line1 = 'Default,'+','.join(ordered)+'\n'
+    line2 = 'HidePython,'+','.join(ordered)+'\n'
+    after = line1 + line2
+    f.truncate()
+    f.write(after)
 
 def build_permutation(apps, appsOrdered):
     res = [0] * len(apps)
@@ -29,6 +38,8 @@ def parse_config_file(layouts, apps):
     with io.open(layouts, "r", encoding="utf-8") as f:
         csvreader = csv.reader(f, delimiter=',')
         for row in csvreader:
+            for stg in row:
+                stg.strip()
             res['styles'].append(row[0])
             res['permutations'].append(build_permutation(apps, row[1:]))
     return res


### PR DESCRIPTION
I did it ! It's my first real modification of Upsilon (and of any c++ project) ! 🎉

I fixed a bug :
When you buid Upsilon changing the app order with the EPSILON_APPS flag, the layout stayed the old one, and the app you clicked on wasn't the shown one.
It's easier to understand with screenshots:
image
and when I click on it, it opens the python app !
image

To fix it, the apps_layout.csv is automaticly updated from the EPSILON_APPS flag in the make command.

The Default and HidePython layouts are both updated because of the same bug: the layout and the content of the home app isn't synchronized (pressing the graph icon doen't mean go to the graph icon, but go to the app n°x, which can be different from the graph app).