### PR TITLE
Fix Numworks not recognizing calculator

### DIFF
--- a/bootloader/interface/static/messages.h
+++ b/bootloader/interface/static/messages.h
@@ -76,7 +76,7 @@ public:
 
   //USB NAMES
   constexpr static const char * usbUpsilonBootloader = "NumWorks Calculator";
-  constexpr static const char * usbUpsilonRecovery = "Upsilon Recovery";
+  constexpr static const char * usbUpsilonRecovery = "NumWorks Calculator";
   constexpr static const char * usbBootloaderUpdate = "Bootloader Update";
 
 };

--- a/bootloader/interface/static/messages.h
+++ b/bootloader/interface/static/messages.h
@@ -75,7 +75,7 @@ public:
   constexpr static const char * bootloaderVersion = "Version 1.0.8 - FREED0M.21.3";
 
   //USB NAMES
-  constexpr static const char * usbUpsilonBootloader = "Upsilon Bootloader";
+  constexpr static const char * usbUpsilonBootloader = "NumWorks Calculator";
   constexpr static const char * usbUpsilonRecovery = "Upsilon Recovery";
   constexpr static const char * usbBootloaderUpdate = "Bootloader Update";
 


### PR DESCRIPTION
Change USB DFU name from "Upsilon Bootloader" to "NumWorks Calculator" to bypass Numworks website security.