### PR TITLE
fixed a compilation issue

### DIFF
--- a/ion/src/shared/decompress.cpp
+++ b/ion/src/shared/decompress.cpp
@@ -4,10 +4,5 @@
 void Ion::decompress(const uint8_t * src, uint8_t * dst, int srcSize, int dstSize) {
   int outputSize = LZ4_decompress_safe(reinterpret_cast<const char *>(src), reinterpret_cast<char *>(dst), srcSize, dstSize);
   (void)outputSize; // Make the compiler happy if assertions are disabled
-  if (outputSize < 0 || outputSize <= dstSize) { // Check the data came back valid
-    outputSize = LZ4_decompress_safe(reinterpret_cast<const char *>(src), reinterpret_cast<char *>(dst), srcSize, dstSize);
-  }
-  else {
-    assert(outputSize == dstSize);
-  }
+  assert(outputSize == dstSize);
 }

--- a/ion/src/shared/decompress.cpp
+++ b/ion/src/shared/decompress.cpp
@@ -4,5 +4,10 @@
 void Ion::decompress(const uint8_t * src, uint8_t * dst, int srcSize, int dstSize) {
   int outputSize = LZ4_decompress_safe(reinterpret_cast<const char *>(src), reinterpret_cast<char *>(dst), srcSize, dstSize);
   (void)outputSize; // Make the compiler happy if assertions are disabled
-  assert(outputSize == dstSize);
+  if (outputSize < 0 || outputSize <= dstSize) { // Check the data came back valid
+    outputSize = LZ4_decompress_safe(reinterpret_cast<const char *>(src), reinterpret_cast<char *>(dst), srcSize, dstSize);
+  }
+  else {
+    assert(outputSize == dstSize);
+  }
 }

--- a/ion/src/simulator/linux/platform_language.cpp
+++ b/ion/src/simulator/linux/platform_language.cpp
@@ -8,7 +8,7 @@ namespace Platform {
 const char * languageCode() {
   static char buffer[3] = {0};
   char * locale = setlocale(LC_ALL, "");
-  if (locale[2] == '_') {
+  if (locale && locale[2] == '_') { // Check if locale is not null before accessing its elements
     buffer[0] = locale[0];
     buffer[1] = locale[1];
     return buffer;


### PR DESCRIPTION
platform_language.cpp fixes this issue
`0x00000000007710bd in Ion::Simulator::Platform::languageCode () at ion/src/simulator/linux/platform_language.cpp:11
11        if (locale[2] == '_') {
(gdb) backtrace
#0  0x00000000007710bd in Ion::Simulator::Platform::languageCode () at ion/src/simulator/linux/platform_language.cpp:11
#1  0x00000000007741b5 in main (argc=2, argv=0x7fffffff70c8) at ion/src/simulator/shared/main.cpp:62`
