### PR TITLE
Fix: correct console text background color

### DIFF
--- a/apps/code/console_line_cell.cpp
+++ b/apps/code/console_line_cell.cpp
@@ -19,7 +19,7 @@ void ConsoleLineCell::ScrollableConsoleLineView::ConsoleLineView::setLine(Consol
 
 void ConsoleLineCell::ScrollableConsoleLineView::ConsoleLineView::drawRect(KDContext * ctx, KDRect rect) const {
   ctx->fillRect(bounds(), Palette::CodeBackground);
-  ctx->drawString(m_line->text(), KDPointZero, GlobalPreferences::sharedGlobalPreferences()->font(), textColor(m_line), isHighlighted()? Palette::Select : Palette::BackgroundApps);
+  ctx->drawString(m_line->text(), KDPointZero, GlobalPreferences::sharedGlobalPreferences()->font(), textColor(m_line), isHighlighted()? Palette::Select : Palette::CodeBackground);
 }
 
 KDSize ConsoleLineCell::ScrollableConsoleLineView::ConsoleLineView::minimalSizeForOptimalDisplay() const {


### PR DESCRIPTION
### Description
This pull request changes the background color used behind console text lines.
Previously, non-highlighted console lines were drawn using `Palette::BackgroundApps`.
This caused a mismatch with the expected `Palette::CodeBackground` used elsewhere in the Python app.

### Changes
- In `console_line_cell.cpp`, replaced:
```cpp
  Palette::BackgroundApps
```

with:

```cpp
Palette::CodeBackground
```

in `ConsoleLineCell::ScrollableConsoleLineView::ConsoleLineView::drawRect()`.