### PR TITLE
[Simulator/Android] Bump Gradle and Java & Add Android on README

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -111,10 +111,10 @@ jobs:
       - run: |
           sudo apt-get update
           sudo apt-get install imagemagick libfreetype-dev libpng-dev
-      - name: Set up JDK 21
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '21'
+          java-version: '25'
           distribution: 'temurin'
       - run: wget -nv https://dl.google.com/android/repository/android-ndk-r21e-linux-x86_64.zip
       - run: unzip -q android-ndk-r21e-linux-x86_64.zip

--- a/README.fr.md
+++ b/README.fr.md
@@ -416,6 +416,26 @@ Le simulateur se trouve dans `output/release/simulator/web/simulator.zip`
 
 <details>
 
+<summary><b>Simulateur Android</b></summary>
+
+Assurez-vous d'avoir JDK 25 d'installé.
+Ensuite, téléchargez la toolchain Android version r21e comme suit :
+```
+export ANDROID_HOME=$PWD/android-sdk
+wget -nv https://gitlab.com/fdroid/sdkmanager/-/raw/master/sdkmanager.py
+python3 sdkmanager.py --licenses
+python3 sdkmanager.py --install "ndk-bundle;r21e"
+```
+Il ne vous reste plus qu'à lancer cette commande pour compiler Upsilon.
+```
+make -j$(nproc) PLATFORM=simulator TARGET=android
+```
+Le fichier compilé nommé `epsilon.apk` sera celui à installer sur le téléphone depuis votre gestionnaire de fichier. Fonctionne normalement à partir de Android 4.
+
+</details>
+
+<details>
+
 <summary><b>Simulateur pour 3DS</b></summary>
 
 Il vous faut devkitPro et devkitARM installés et dans votre path (les instructions sont [ici](https://devkitpro.org/wiki/Getting_Started))

--- a/README.md
+++ b/README.md
@@ -442,7 +442,25 @@ You can then put epsilon.3dsx on a SD card to run it from the HBC or use 3dslink
 
 </details>
 
-<br>
+<details>
+
+<summary><b>Android Simulator</b></summary>
+
+Make sure you have JDK 25 installed.
+Then, download the Android toolchain r21e as following :
+```
+export ANDROID_HOME=$PWD/android-sdk
+wget -nv https://gitlab.com/fdroid/sdkmanager/-/raw/master/sdkmanager.py
+python3 sdkmanager.py --licenses
+python3 sdkmanager.py --install "ndk-bundle;r21e"
+```
+All you have to do is run this command to compile Upsilon.
+```
+make -j$(nproc) PLATFORM=simulator TARGET=android
+```
+The compiled file named `epsilon.apk` will be the one to install on the phone from your file manager. Shoudl work on Android 4.1+.
+
+</details>
 
 <details>
   <summary><b>Casio fx-CG-series Port</b></summary>

--- a/ion/src/simulator/android/build.gradle
+++ b/ion/src/simulator/android/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.8.1'
+    classpath 'com.android.tools.build:gradle:8.13.0'
   }
 }
 
@@ -32,10 +32,10 @@ apply plugin: 'com.android.application'
 
 android {
   namespace = "io.github.upsilon.simulator"
-  compileSdkVersion 35
+  compileSdkVersion 36
   defaultConfig {
     applicationId "io.github.upsilon.simulator"
-    minSdkVersion 21
+    minSdkVersion 16
     targetSdkVersion 33
     def d=new Date()
     versionCode Instant.now().getEpochSecond().toInteger()
@@ -77,8 +77,8 @@ android {
 
 dependencies {
   implementation fileTree(include: ['*.jar'], dir: 'libs')
-  implementation "androidx.appcompat:appcompat:1.7.0"
-  implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.1.10"))
+  implementation "androidx.appcompat:appcompat:1.6.0"
+  implementation(platform("org.jetbrains.kotlin:kotlin-bom:2.2.21"))
 }
 
-java{toolchain{languageVersion=JavaLanguageVersion.of(21)}}
+java{toolchain{languageVersion=JavaLanguageVersion.of(25)}}

--- a/ion/src/simulator/android/gradle/wrapper/gradle-wrapper.properties
+++ b/ion/src/simulator/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 


### PR DESCRIPTION
I've added instructions to build Android on both README, and updated Gradle to V9 and Java 21 → 25. Upsilon is now available for Android 4.1+, not only for Android 5.0+ (but I don't think that a lot of people would notice that 😅).